### PR TITLE
Adding licenses for code adapted from elsewhere

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -399,15 +399,13 @@ SOFTWARE.
 
 ## R/plot_lineage_ts.R
 
-The functions in R/plot_lineage_ts.R were adapted from code in the  
-[boydorr/PembaRabies](https://github.com/boydorr/PembaRabies) GitHub repository,
-as well as a private GitHub repository owned by Kennedy Lushasi.
+The function `plot_lin_ts()` was adapted from a private GitHub repository owned
+by Kennedy Lushasi. Permission has been granted to use, modify, and distribute 
+this code without restrictions.
 
-Code from Kennedy Lushasi's repository (the `plot_lin_ts()` function) was shared
-with permission. Do not redistribute without further consent from the owner.
-
-Code from the boydorr/PembaRabies repository (within `plot_epicurve()` and 
-`plot_map_w_lin_cases()`) is licensed under the MIT License. The full text of 
+The functions `plot_epicurve()` and `plot_map_w_lin_cases()` were adapted from 
+code in the [boydorr/PembaRabies](https://github.com/boydorr/PembaRabies) 
+GitHub repository, which is licensed under the MIT License. The full text of 
 the MIT License is included below:
 
 Copyright (c) 2022 Katie Hampson

--- a/LICENSE
+++ b/LICENSE
@@ -369,3 +369,30 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+## 
+
+This repository contains various scripts adapted from the 
+[boydorr/PembaRabies](https://github.com/boydorr/PembaRabies) and 
+[boydorr/Pemba_rabies](https://github.com/boydorr/Pemba_rabies) repositories, 
+which are licensed under the MIT License. The full text of the MIT License is 
+included below:
+
+Copyright (c) 2022 Katie Hampson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -340,12 +340,12 @@ consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
 
-# MIT-Licensed Components
+# Additional Licenses and Copyright Notices
 
 ## R/boot_trees_simulate_location.R
 
-This repository contains a function (R/boot_trees_simulate_location.R) adapted 
-from the [treerabid](https://github.com/mrajeev08/treerabid) R package, which 
+The function in R/boot_trees_simulate_location.R was adapted from boot_trees() 
+of the [treerabid](https://github.com/mrajeev08/treerabid) R package, which 
 is licensed under the MIT License. The full text of the MIT License is included 
 below:
 
@@ -369,13 +369,46 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-## 
+## R/run_treerabid.R, R/plot_tm_trees_epi_gen_sim_loc_pruned.R, R/animate_trees_on_map.R, R/plot_tm_tree_comparisons.R
 
-This repository contains various scripts adapted from the 
-[boydorr/PembaRabies](https://github.com/boydorr/PembaRabies) and 
-[boydorr/Pemba_rabies](https://github.com/boydorr/Pemba_rabies) repositories, 
-which are licensed under the MIT License. The full text of the MIT License is 
+The scripts R/run_treerabid.R, R/plot_tm_trees_epi_gen_sim_loc_pruned.R, R/animate_trees_on_map.R 
+and R/plot_tm_tree_comparisons.R contain code adapted from the  
+[boydorr/PembaRabies](https://github.com/boydorr/PembaRabies) GitHub repository, 
+which is licensed under the MIT License. The full text of the MIT License is 
 included below:
+
+Copyright (c) 2022 Katie Hampson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## R/plot_lineage_ts.R
+
+The functions in R/plot_lineage_ts.R were adapted from code in the  
+[boydorr/PembaRabies](https://github.com/boydorr/PembaRabies) GitHub repository,
+as well as a private GitHub repository owned by Kennedy Lushasi.
+
+Code from Kennedy Lushasi's repository (the `plot_lin_ts()` function) was shared
+with permission. Do not redistribute without further consent from the owner.
+
+Code from the boydorr/PembaRabies repository (within `plot_epicurve()` and 
+`plot_map_w_lin_cases()`) is licensed under the MIT License. The full text of 
+the MIT License is included below:
 
 Copyright (c) 2022 Katie Hampson
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+# GPL-2 License
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
@@ -337,3 +339,33 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
+
+# MIT-Licensed Components
+
+## R/boot_trees_simulate_location.R
+
+This repository contains a function (R/boot_trees_simulate_location.R) adapted 
+from the [treerabid](https://github.com/mrajeev08/treerabid) R package, which 
+is licensed under the MIT License. The full text of the MIT License is included 
+below:
+
+Copyright (c) 2021 Malavika Rajeev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/R/animate_trees_on_map.R
+++ b/R/animate_trees_on_map.R
@@ -1,3 +1,29 @@
+# This function was adapted from a
+# [script in the boydorr/PembaRabies GitHub repository](https://github.com/boydorr/PembaRabies/blob/main/6b.trees_main.R)
+# by Carlijn Bogaardt in January 2024.
+# The original script is licensed under the MIT license, the full text of which 
+# is included below:
+#  
+#   Copyright (c) 2022 Katie Hampson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#   
+#   The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 library(ggplot2)
 library(data.table)
 library(ggforce)

--- a/R/boot_trees_simulate_location.R
+++ b/R/boot_trees_simulate_location.R
@@ -1,11 +1,16 @@
 library(doRNG)
 library(foreach)
 
-#' Adapted version of treerabid::boot_trees() that samples case locations within
-#' given localities, based on population size per 100m2 cell. 
-#' N.B. Unlike the original boot_trees, this function assumes use_known_source 
-#' is FALSE! (conditional calling of build_known_tree() has been removed)
-#'
+#' @title Bootstrapped trees with simulated case locations
+#' @description 
+#' This function was adapted from treerabid::boot_trees() by Carlijn 
+#' Bogaardt on 13 February 2024, in order to incorporate case location sampling
+#' within given localities based on population size. The treerabid packages is 
+#' licensed under the MIT license.
+#' 
+#' Unlike the original boot_trees, this function assumes use_known_source is 
+#' FALSE (i.e. conditional calling of build_known_tree() has been removed).
+#' 
 #' @inheritParams treerabid::build_tree
 #' @param N number of trees to build
 #' @param seed seed to pass to doRNG to make trees reproducible
@@ -20,6 +25,35 @@ library(foreach)
 #' @return a data.table with bootstrapped trees
 #' @importFrom foreach foreach
 #' @importFrom doRNG %dorng%
+#' 
+#' @details 
+#' This function is adapted from the original work in the `treerabid` package, 
+#' licensed under the MIT License.
+#' 
+#' \preformatted{
+#' Copyright (c) 2021 Malavika Rajeev
+#' 
+#' Permission is hereby granted, free of charge, to any person obtaining a copy
+#' of this software and associated documentation files (the "Software"), to deal
+#' in the Software without restriction, including without limitation the rights
+#' to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+#' of the Software, and to permit persons to whom the Software is furnished to do so,
+#' subject to the following conditions:
+#' 
+#' The above copyright notice and this permission notice shall be included in all
+#' copies or substantial portions of the Software.
+#'
+#' THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#' IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#' FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#' AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#' LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#' OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#' SOFTWARE.
+#' }
+#' @author Malavika Rajeev (treerabid package)
+#' @author Carlijn Bogaardt (adapted code only)
+#' 
 boot_trees_simulate_location <- function(id_case,
                        id_biter,
                        locality,

--- a/R/boot_trees_simulate_location.R
+++ b/R/boot_trees_simulate_location.R
@@ -5,7 +5,7 @@ library(foreach)
 #' @description 
 #' This function was adapted from treerabid::boot_trees() by Carlijn 
 #' Bogaardt on 13 February 2024, in order to incorporate case location sampling
-#' within given localities based on population size. The treerabid packages is 
+#' within given localities based on population size. The treerabid package is 
 #' licensed under the MIT license.
 #' 
 #' Unlike the original boot_trees, this function assumes use_known_source is 

--- a/R/plot_lineage_ts.R
+++ b/R/plot_lineage_ts.R
@@ -3,8 +3,7 @@
 # and a private GitHub repository owned by Kennedy Lushasi. The code was adapted
 # by Carlijn Bogaardt in January 2024. 
 # Sources have been attributed in the function documentation.
-# Code from Kennedy Lushasi was shared with permission. Do not redistribute 
-# without further consent from the owner.
+# Code from Kennedy Lushasi was modified and shared with permission.
 # Code from the boydorr/PembaRabies repository is licensed under the MIT 
 # license, the full text of which is included below:
 #  

--- a/R/plot_lineage_ts.R
+++ b/R/plot_lineage_ts.R
@@ -1,3 +1,33 @@
+# The functions in this file contain code adapted from original scripts in 
+# [boydorr/PembaRabies](https://github.com/boydorr/PembaRabies/blob/main/6b.trees_main.R)
+# and a private GitHub repository owned by Kennedy Lushasi. The code was adapted
+# by Carlijn Bogaardt in January 2024. 
+# Sources have been attributed in the function documentation.
+# Code from Kennedy Lushasi was shared with permission. Do not redistribute 
+# without further consent from the owner.
+# Code from the boydorr/PembaRabies repository is licensed under the MIT 
+# license, the full text of which is included below:
+#  
+#   Copyright (c) 2022 Katie Hampson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#   
+#   The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 library(treerabid)
 library(data.table)
 library(ggthemes)
@@ -9,6 +39,10 @@ library(igraph)
 library(ggraph)
 
 #' Plot transmission trees on a timeline
+#' 
+#' @description 
+#' This function was adapted from the original plot_lin_ts() in Kennedy Lushasi's
+#' private repository, by Carlijn Bogaardt in January 2024. Used with permission.
 #'
 #' @param links_consensus Output from `treerabid::build_consensus_links()`.
 #' @param case_dates A `data.table` with 2 columns, named `"id_case"` (with case 
@@ -28,6 +62,8 @@ library(ggraph)
 #'
 #' @return A plot with transmission trees, and a timeline as x-axis.
 #' 
+#' @author Kennedy Lushasi (most code)
+#' @author Carlijn Bogaardt (adaptations only)
 plot_lin_ts <- function(links_consensus, case_dates, 
                         colour_by = "lineage_chain",
                         colour_edges = TRUE,
@@ -139,7 +175,13 @@ plot_lin_ts <- function(links_consensus, case_dates,
 }
 
 #' Plot an epicurve (case histogram) coloured by lineage or transmission chain
-#'
+#' 
+#' @description
+#' This function was adapted from code in the 6b.trees_main.R script in the 
+#' [boydorr/PembaRabies](https://github.com/boydorr/PembaRabies/blob/main/6b.trees_main.R)
+#' GitHub repository by Carlijn Bogaardt in January 2024. The boydorr/PembaRabies
+#' repository is licensed under the MIT license.
+#' 
 #' @param links_consensus Output from `treerabid::build_consensus_links()`.
 #' @param case_dates A `data.table` with 2 columns, named `"id_case"` (with case 
 #'   identifiers) and `"symptoms_started"` (with dates in `Date` class).
@@ -151,6 +193,34 @@ plot_lin_ts <- function(links_consensus, case_dates,
 #'   upper-left corner of the figure.
 #'
 #' @return An epicurve (case histogram) plot, with a timeline as x-axis.
+#' 
+#' @details
+#' This function is adapted from the original work in the boydorr/PembaRabies 
+#' repository, licensed under the MIT License.
+#' 
+#' \preformatted{
+#' Copyright (c) 2022 Katie Hampson
+#' 
+#' Permission is hereby granted, free of charge, to any person obtaining a copy
+#' of this software and associated documentation files (the "Software"), to deal
+#' in the Software without restriction, including without limitation the rights
+#' to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+#' of the Software, and to permit persons to whom the Software is furnished to do so,
+#' subject to the following conditions:
+#' 
+#' The above copyright notice and this permission notice shall be included in all
+#' copies or substantial portions of the Software.
+#'
+#' THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#' IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#' FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#' AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#' LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#' OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#' SOFTWARE.
+#' }
+#' @author Katie Hampson (main code)
+#' @author Carlijn Bogaardt (adaptations only)
 
 plot_epicurve <- function(links_consensus, case_dates, 
                           colour_by = "lineage_chain",
@@ -201,6 +271,12 @@ plot_epicurve <- function(links_consensus, case_dates,
 
 #' Plot a map with cases coloured by lineage or transmission chain
 #' 
+#' @description
+#' This function was adapted from code in the 6b.trees_main.R script in the 
+#' [boydorr/PembaRabies](https://github.com/boydorr/PembaRabies/blob/main/6b.trees_main.R)
+#' GitHub repository by Carlijn Bogaardt in January 2024. The boydorr/PembaRabies
+#' repository is licensed under the MIT license.
+#' 
 #' @param links_consensus Output from `treerabid::build_consensus_links()`.
 #' @param case_coords A `data.table` with case coordinates, using the Universal 
 #'   Transverse Mercator coordinate system. This needs to include 3 columns with 
@@ -215,7 +291,34 @@ plot_epicurve <- function(links_consensus, case_dates,
 #'
 #' @return A map of the outbreak area, with cases coloured by lineage or 
 #'   transmission chain.
+#'   
+#' @details
+#' This function is adapted from the original work in the boydorr/PembaRabies 
+#' repository, licensed under the MIT License.
 #' 
+#' \preformatted{
+#' Copyright (c) 2022 Katie Hampson
+#' 
+#' Permission is hereby granted, free of charge, to any person obtaining a copy
+#' of this software and associated documentation files (the "Software"), to deal
+#' in the Software without restriction, including without limitation the rights
+#' to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+#' of the Software, and to permit persons to whom the Software is furnished to do so,
+#' subject to the following conditions:
+#' 
+#' The above copyright notice and this permission notice shall be included in all
+#' copies or substantial portions of the Software.
+#'
+#' THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#' IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#' FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#' AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#' LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#' OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#' SOFTWARE.
+#' }
+#' @author Katie Hampson (main code)
+#' @author Carlijn Bogaardt (adaptations only)
 plot_map_w_lin_cases <- function(links_consensus, case_coords,
                                  map,
                                  colour_by = "lineage_chain",

--- a/R/plot_tm_trees_comparisons.R
+++ b/R/plot_tm_trees_comparisons.R
@@ -1,3 +1,29 @@
+# The code in this script was adapted from the 
+# [original in the boydorr/PembaRabies GitHub repository](https://github.com/boydorr/PembaRabies/blob/main/6c.trees_se.R)
+# by Carlijn Bogaardt in January 2024.
+# The original script is licensed under the MIT license, the full text of which 
+# is included below:
+#  
+#   Copyright (c) 2022 Katie Hampson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#   
+#   The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # Comparison of consensus trees across 28 scenarios ----
 
 library(ggplot2)

--- a/R/plot_tm_trees_epi_gen_sim_loc_pruned.R
+++ b/R/plot_tm_trees_epi_gen_sim_loc_pruned.R
@@ -1,3 +1,35 @@
+# This script contains code adapted from the 
+# [original in the boydorr/PembaRabies GitHub repository](https://github.com/boydorr/PembaRabies/blob/main/6b.trees_main.R)
+# by Carlijn Bogaardt in January 2024.
+# Bits of code that have been copied or directly adapted from the above 
+# repository have been marked with "### Adapted from boydorr/PembaRabies ###"
+# and "### End adaptation from boydorr/PembaRabies ###".
+# The original script is licensed under the MIT license, the full text of which 
+# is included below:
+#  
+#   Copyright (c) 2022 Katie Hampson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#   
+#   The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+### Adapted from boydorr/PembaRabies ###
+
 library(ggplot2)
 library(treerabid)
 library(lubridate)
@@ -26,7 +58,10 @@ case_dates <- data.table(id_case = animal_cases$id,
 links_consensus <- links_consensus[scenario == 12]
 ttrees <- ttrees[scenario == 12]
 mcc_tree <- ttrees[mcc == 1]
-maj_tree <- ttrees[majority == 1]
+maj_tree <- ttrees
+
+### End adaptation from boydorr/PembaRabies ###
+
 
 # output table with membership, lineage_chain and lineage identifiers for each case ----
 links_consensus %>%
@@ -157,6 +192,7 @@ case_data <-
          utm_easting = utm_easting_centroid,
          utm_northing = utm_northing_centroid)
 
+### Adapted from boydorr/PembaRabies ###
 ### make gif with animation and save as a movie (more manageable file size and res than gif/pdf)
 saveVideo({ 
   animate_trees_on_map(links_consensus, case_data, map = Romblon_shp,
@@ -169,3 +205,5 @@ saveVideo({
     c('Reconstructed transmission trees using lognormal SI and weibull dk'),
   interval = 1, nmax = 50, ani.dev = "png", ani.type = "png",
   ani.width = 1500, ani.height = 2000, ani.res = 300)
+
+### End adaptation from boydorr/PembaRabies ###

--- a/R/run_treerabid.R
+++ b/R/run_treerabid.R
@@ -1,6 +1,31 @@
+# The code in this script was adapted from the 
+# [original in the boydorr/PembaRabies GitHub repository](https://github.com/boydorr/PembaRabies/blob/main/6.TransmissionTrees.R)
+# by Carlijn Bogaardt in January 2024.
+# The original script is licensed under the MIT license, the full text of which 
+# is included below:
+#  
+#   Copyright (c) 2022 Katie Hampson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#   
+#   The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 library(here)
 library(readr)
-library(data.table)
 library(treerabid)
 library(data.table)
 library(dplyr)

--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ pastml -t processed_data/dated_trees/all_wgsrate_lsd_CI.date.nexus -d processed_
 ## License
 This repository is licensed under the GPL-2 License. However, it includes code 
 adapted from the [treerabid](https://github.com/mrajeev08/treerabid) R package
-and from the [boydorr/PembaRabies](https://github.com/boydorr/PembaRabies) and 
-[boydorr/Pemba_rabies](https://github.com/boydorr/Pemba_rabies) repositories, 
-which are licensed under the MIT License. For more details, see the `LICENSE` file.
+and the [boydorr/PembaRabies](https://github.com/boydorr/PembaRabies) 
+repository, which are licensed under the MIT License, as well as code adapted
+from a private repository owned by Kennedy Lushasi, which has been shared with
+permission. For more details, see the `LICENSE` file.
 
 
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ pastml -t processed_data/dated_trees/all_wgsrate_lsd_CI.date.nexus -d processed_
 3. simulate_to_first_case.R for case detection simulations, which uses helper functions defined in simulate_helper_fun.R
    
 ## License
-This repository is licensed under the GPL-2 License. However, it includes code adapted from the `treerabid` R package, which is licensed under the MIT License. For more details, see the `LICENSE` file.
+This repository is licensed under the GPL-2 License. However, it includes code 
+adapted from the [treerabid](https://github.com/mrajeev08/treerabid) R package
+and from the [boydorr/PembaRabies](https://github.com/boydorr/PembaRabies) and 
+[boydorr/Pemba_rabies](https://github.com/boydorr/Pemba_rabies) repositories, 
+which are licensed under the MIT License. For more details, see the `LICENSE` file.
 
 
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ pastml -t processed_data/dated_trees/all_wgsrate_lsd_CI.date.nexus -d processed_
 
 3. simulate_to_first_case.R for case detection simulations, which uses helper functions defined in simulate_helper_fun.R
    
-   
+## License
+This repository is licensed under the GPL-2 License. However, it includes code adapted from the `treerabid` R package, which is licensed under the MIT License. For more details, see the `LICENSE` file.
+
 
 
 


### PR DESCRIPTION
I've added licenses and copyright notices for code adapted from treerabid and the public Pemba repositories (both MIT licensed), and a permission note regarding the plot_lin_ts() function copied from Kennedy's private repository.